### PR TITLE
Update dependencies and fix bugs in codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ dmypy.json
 
 # VS Code
 .vscode/
+
+# AI md files
+GEMINI.md
+CLAUDE.md

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2,7 +2,7 @@ CLI
 =============
 
 PyEPP comes with a command line interface that allows the user to interact with the registry system. It will be installed
-the main library.
+with the main library.
 
 .. code-block:: text
 
@@ -316,4 +316,60 @@ host
            </info>
            <clTRID>dab02e31-5658-44c4-bbd5-ff66b88539b5</clTRID>
          </command>
+        </epp>
+
+poll
+^^^^^^^^^^^
+
+.. code-block:: text
+
+    sh> pyepp poll request
+        <?xml version="1.0" encoding="utf-8"?>
+        <epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:contact="urn:ietf:params:xml:ns:contact-1.0" xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xmlns:host="urn:ietf:params:xml:ns:host-1.0" xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0" xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
+         <response>
+          <result code="1301">
+           <msg>
+            Command completed successfully; ack to dequeue
+           </msg>
+          </result>
+          <msgQ count="5" id="12345">
+           <qDate>
+            2024-04-12T00:41:59.977Z
+           </qDate>
+           <msg>
+            Transfer requested.
+           </msg>
+          </msgQ>
+          <trID>
+           <clTRID>
+            poll-req-1234
+           </clTRID>
+           <svTRID>
+            CIRA-000232270901-0000000003
+           </svTRID>
+          </trID>
+         </response>
+        </epp>
+
+.. code-block:: text
+
+    sh> pyepp poll acknowledge 12345
+        <?xml version="1.0" encoding="utf-8"?>
+        <epp xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:contact="urn:ietf:params:xml:ns:contact-1.0" xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xmlns:host="urn:ietf:params:xml:ns:host-1.0" xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0" xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
+         <response>
+          <result code="1000">
+           <msg>
+            Command completed successfully
+           </msg>
+          </result>
+          <msgQ count="4" id="12345"/>
+          <trID>
+           <clTRID>
+            poll-ack-12345
+           </clTRID>
+           <svTRID>
+            CIRA-000232270901-0000000004
+           </svTRID>
+          </trID>
+         </response>
         </epp>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ PyEPP
 This is a Python API on `EPP <https://en.wikipedia.org/wiki/Extensible_Provisioning_Protocol>`_
 protocol to connect to any registry systems that support EPP and manage the registry objects.
 Also, it is a CLI client to interact with the registry systems.
-It supports the bellow RFCs:
+It supports the below RFCs:
 
 * `RFC 5730 - Extensible Provisioning Protocol <https://datatracker.ietf.org/doc/html/rfc5730>`_
 * `RFC 5731 - Domain Name Mapping <https://datatracker.ietf.org/doc/html/rfc5731>`_
@@ -30,6 +30,7 @@ Usage example
    from pyepp import EppCommunicator
    from pyepp.domain import Domain, DomainData, DSRecordData, DNSSECAlgorithm, DigestTypeEnum
    from pyepp.contact import Contact, ContactData, PostalInfoData, AddressData
+   from pyepp.host import Host, HostData, IPAddressData
 
    config = {
        "server": "epp.test.net.nz",
@@ -86,12 +87,12 @@ Usage example
        billing='contact-3',
        period=3,
        host=['01y.test-indwrx2vkicn2otgm3otav5wpnzvjd.co.nz', '0d9x6239.example.co.nz'],
-       dns_sec=DSRecordData(
+       dns_sec=[DSRecordData(
            key_tag=1235,
            algorithm=DNSSECAlgorithm.DSA_SHA_1.value,
            digest_type=DigestTypeEnum.SHA_1.value,
            digest='8cdb09364147aed879d12c68d615f98af5900b73'
-       ),
+       )],
    )
    domain_create = domain.create(domain_create_params)
 
@@ -135,7 +136,6 @@ PyEPP also has a command line interface that allows the user to interact with th
       host     To work with Host objects in the registry.
       poll     To manage registry service messages.
       run      Receive an XML file containing an EPP XML command and execute it.
-
 
 .. toctree::
    :maxdepth: 2

--- a/pyepp/__init__.py
+++ b/pyepp/__init__.py
@@ -2,7 +2,7 @@
 PyEPP Package
 """
 
-__version__ = "0.1.8"
+__version__ = "0.2.0"
 
 from pyepp.epp import (
     EppCommunicator,

--- a/pyepp/base_command.py
+++ b/pyepp/base_command.py
@@ -1,6 +1,9 @@
 """
 Base command
 """
+
+from typing import Any
+
 import uuid
 
 from dataclasses import dataclass
@@ -21,6 +24,7 @@ class BaseCommand:
     """
     Base command class. Other EPP commands will inherit this class.
     """
+
     PARAMS = ()
 
     def __init__(self, epp_communicator: EppCommunicator) -> None:
@@ -42,7 +46,7 @@ class BaseCommand:
         result = self._epp_communicator.execute(cmd)
         return result
 
-    def _prepare_command(self, cmd: str, **kwargs: str) -> str:
+    def _prepare_command(self, cmd: str, **kwargs: Any) -> str:
         """Prepare an EPP XML command for execution by setting up the arguments.
 
         :param cmd: Command in XML format
@@ -50,10 +54,12 @@ class BaseCommand:
 
         :return: XML command
         """
-        if cmd.find('client_transaction_id') != -1 and not kwargs.get('client_transaction_id'):
-            kwargs['client_transaction_id'] = str(uuid.uuid4())
+        if cmd.find("client_transaction_id") != -1 and not kwargs.get(
+            "client_transaction_id"
+        ):
+            kwargs["client_transaction_id"] = str(uuid.uuid4())
 
-        kwargs = {key: value for key, value in kwargs.items() if value}
+        kwargs = {key: value for key, value in kwargs.items() if value is not None}
 
         new_kwargs = self.__escape_dict(kwargs)
 
@@ -72,7 +78,7 @@ class BaseCommand:
                 result.append(self.__escape_dict(value))
             elif isinstance(value, str):
                 result.append(escape(value))
-            elif value:
+            elif value is not None:
                 result.append(value)
 
         return result
@@ -87,7 +93,7 @@ class BaseCommand:
                 result[key] = self.__escape_dict(value)
             elif isinstance(value, str):
                 result[key] = escape(value)
-            elif value:
+            elif value is not None:
                 result[key] = value
 
         return result

--- a/pyepp/command_templates.py
+++ b/pyepp/command_templates.py
@@ -243,20 +243,27 @@ DOMAIN_CREATE_XML = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
     {% if dns_sec %}
     <extension>
       <secDNS:create xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
+        {% if dns_sec is mapping %}
+          {% set dns_sec_list = [dns_sec] %}
+        {% else %}
+          {% set dns_sec_list = dns_sec %}
+        {% endif %}
+        {% for ds in dns_sec_list %}
         <secDNS:dsData>
-          <secDNS:keyTag>{{ dns_sec.get('key_tag') }}</secDNS:keyTag>
-          <secDNS:alg>{{ dns_sec.get('algorithm') }}</secDNS:alg>
-          <secDNS:digestType>{{ dns_sec.get('digest_type') }}</secDNS:digestType>
-          <secDNS:digest>{{ dns_sec.get('digest') }}</secDNS:digest>
-          {% if dns_sec.get('dns_key') %}
+          <secDNS:keyTag>{{ ds.get('key_tag') }}</secDNS:keyTag>
+          <secDNS:alg>{{ ds.get('algorithm') }}</secDNS:alg>
+          <secDNS:digestType>{{ ds.get('digest_type') }}</secDNS:digestType>
+          <secDNS:digest>{{ ds.get('digest') }}</secDNS:digest>
+          {% if ds.get('dns_key') %}
           <secDNS:keyData>
-            <secDNS:flags>{{ dns_sec.get('dns_key').get('flag') }}</secDNS:flags>
-            <secDNS:protocol>{{ dns_sec.get('dns_key').get('protocol') }}</secDNS:protocol>
-            <secDNS:alg>{{ dns_sec.get('dns_key').get('algorithm') }}</secDNS:alg>
-            <secDNS:pubKey>{{ dns_sec.get('dns_key').get('public_key') }}</secDNS:pubKey>
+            <secDNS:flags>{{ ds.get('dns_key').get('flag') }}</secDNS:flags>
+            <secDNS:protocol>{{ ds.get('dns_key').get('protocol') }}</secDNS:protocol>
+            <secDNS:alg>{{ ds.get('dns_key').get('algorithm') }}</secDNS:alg>
+            <secDNS:pubKey>{{ ds.get('dns_key').get('public_key') }}</secDNS:pubKey>
           </secDNS:keyData>
           {% endif %}
         </secDNS:dsData>
+        {% endfor %}
         {% if dns_key %}
         <secDNS:keyData>
           <secDNS:flags>{{ dns_key.dns_key.get('flag') }}</secDNS:flags>
@@ -310,7 +317,7 @@ TRANSFER_REQUEST_XML = """<?xml version="1.0" encoding="UTF-8"?>
       <domain:period unit='y'>{{ period }}</domain:period>
       {% endif %}
       <domain:authInfo>
-        <domain:pw>{{ password }}</domains:pw>
+        <domain:pw>{{ password }}</domain:pw>
       </domain:authInfo>
     </domain:transfer>
   </transfer>

--- a/pyepp/epp.py
+++ b/pyepp/epp.py
@@ -72,23 +72,7 @@ def get_format_32() -> str:
 
     From http://www.bortzmeyer.org/4934.html
     """
-    format_32 = ">I"
-    if struct.calcsize(format_32) < LENGTH_FIELD_SIZE:
-        format_32 = ">L"
-        if struct.calcsize(format_32) != LENGTH_FIELD_SIZE:
-            logging.error("Integer size does not match the length size!")
-            raise EppCommunicatorException(
-                "Integer size does not match the length size!"
-            )
-    elif struct.calcsize(format_32) > LENGTH_FIELD_SIZE:
-        format_32 = ">H"
-        if struct.calcsize(format_32) != LENGTH_FIELD_SIZE:
-            logging.error("Integer size does not match the length size!")
-            raise EppCommunicatorException(
-                "Integer size does not match the length size!"
-            )
-
-    return format_32
+    return ">I"
 
 
 # pylint: disable=too-many-instance-attributes
@@ -186,7 +170,7 @@ class EppCommunicator:
         Read the response from the socket.
 
         :return: Response
-        :rtype: bytes
+        :rtype: Optional[bytes]
         """
         length = self._ssl_socket.read(LENGTH_FIELD_SIZE)
         buffer = bytes()
@@ -196,8 +180,11 @@ class EppCommunicator:
 
         total_bytes = self._unpack_data(length) - LENGTH_FIELD_SIZE
         while len(buffer) < total_bytes:
-            total_bytes = total_bytes - len(buffer)
-            buffer += self._ssl_socket.recv(total_bytes)
+            remaining = total_bytes - len(buffer)
+            chunk = self._ssl_socket.recv(remaining)
+            if not chunk:
+                return None
+            buffer += chunk
             logging.info("Received %s/%s bytes", len(buffer), total_bytes)
         return buffer
 
@@ -215,9 +202,11 @@ class EppCommunicator:
         xml_bytes = xml.encode("utf-8")
         length = self._pack_data(len(xml_bytes) + LENGTH_FIELD_SIZE + CRLF_SIZE)
 
-        self._ssl_socket.send(length)
+        self._ssl_socket.sendall(length)
         xml += "\r\n"
-        return self._ssl_socket.send(xml.encode("utf-8"))
+        data_to_send = xml.encode("utf-8")
+        self._ssl_socket.sendall(data_to_send)
+        return len(data_to_send)
 
     def _execute_command(self, cmd: str) -> bytes:
         """

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 bandit==1.9.2
-coverage==7.13.1
+coverage==7.13.4
 pylint==4.0.4
 pytest==9.0.2
 pip-audit==2.10.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
-bandit==1.9.2
-coverage==7.13.4
-pylint==4.0.4
+bandit==1.9.4
+coverage==7.14.0
+pylint==4.0.5
 pytest==9.0.3
 pip-audit==2.10.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 bandit==1.9.2
 coverage==7.13.1
 pylint==4.0.4
-pytest==9.0.2
+pytest==9.0.3
 pip-audit==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jinja2==3.1.6
-lxml==6.0.2
+lxml==6.1.1
 beautifulsoup4==4.14.3
-click==8.3.1
+click==8.4.0

--- a/tests/test_base_command.py
+++ b/tests/test_base_command.py
@@ -51,16 +51,34 @@ class BaseCommandTest(unittest.TestCase):
 
         self.assertEqual(expected_result, result)
 
+    def test_prepare_command_falsy_values(self) -> None:
+        """_prepare_command must preserve falsy values like 0 and False."""
+        command = """<?xml version="1.0" encoding="UTF-8"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0"><command><val1>{{ val1 }}</val1><val2>{{ val2 }}</val2></command></epp>"""
+        expected_result = """<?xml version="1.0" encoding="UTF-8"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0"><command><val1>0</val1><val2>False</val2></command></epp>"""
+        epp_communicator = MagicMock(EppCommunicator)
+
+        base_command = BaseCommand(epp_communicator)
+        result = base_command._prepare_command(command, val1=0, val2=False)
+
+        self.assertEqual(expected_result, result)
+
     def test_escape_list(self) -> None:
         test_list = [
             ['hi&', '<world>'],
             {'key': '<hello&world>'},
-            '<hello&world>'
+            '<hello&world>',
+            0,
+            False,
+            None
         ]
         expected_result = [
             ['hi&amp;', '&lt;world&gt;'],
             {'key': '&lt;hello&amp;world&gt;'},
-            '&lt;hello&amp;world&gt;'
+            '&lt;hello&amp;world&gt;',
+            0,
+            False
         ]
 
         epp_communicator = MagicMock(EppCommunicator)
@@ -71,21 +89,25 @@ class BaseCommandTest(unittest.TestCase):
         self.assertEqual(expected_result, result)
 
     def test_escape_dict(self) -> None:
-        test_list = {
+        test_dict = {
             'key1': ['hi&', '<world>'],
             'key2': {'key': '<hello&world>'},
-            'key3': '<hello&world>'
+            'key3': '<hello&world>',
+            'key4': 0,
+            'key5': False
         }
         expected_result = {
             'key1': ['hi&amp;', '&lt;world&gt;'],
             'key2': {'key': '&lt;hello&amp;world&gt;'},
-            'key3': '&lt;hello&amp;world&gt;'
+            'key3': '&lt;hello&amp;world&gt;',
+            'key4': 0,
+            'key5': False
         }
 
         epp_communicator = MagicMock(EppCommunicator)
         base_command = BaseCommand(epp_communicator)
 
-        result = base_command._BaseCommand__escape_dict(test_list)
+        result = base_command._BaseCommand__escape_dict(test_dict)
 
         self.assertEqual(expected_result, result)
 

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -1,6 +1,7 @@
 """
 Contact unit tests
 """
+
 import unittest
 from unittest.mock import MagicMock
 
@@ -18,53 +19,53 @@ class ContactTest(unittest.TestCase):
 
     def test_data_to_dict(self) -> None:
         data = ContactData(
-            id='id',
-            status=['status1', 'status2'],
-            create_date='create_date',
-            creat_client_id='creat_client_id',
-            sponsoring_client_id='sponsoring_client_id',
-            update_client_id='update_client_id',
-            update_date='update_date',
+            id="id",
+            status=["status1", "status2"],
+            create_date="create_date",
+            creat_client_id="creat_client_id",
+            sponsoring_client_id="sponsoring_client_id",
+            update_client_id="update_client_id",
+            update_date="update_date",
             postal_info=PostalInfoData(
-                name='name',
-                organization='organization',
+                name="name",
+                organization="organization",
                 address=AddressData(
-                    street_1='street_1',
-                    street_2='street_2',
-                    street_3='street_3',
-                    city='city',
-                    province='province',
-                    postal_code='postal_code',
-                    country_code='country_code',
+                    street_1="street_1",
+                    street_2="street_2",
+                    street_3="street_3",
+                    city="city",
+                    province="province",
+                    postal_code="postal_code",
+                    country_code="country_code",
                 ),
             ),
-            phone='phone',
-            fax='fax',
-            email='email',
-            password='',
+            phone="phone",
+            fax="fax",
+            email="email",
+            password="",
         )
 
         expected_result = {
-            'id': 'id',
-            'status': ['status1', 'status2'],
-            'create_date': 'create_date',
-            'creat_client_id': 'creat_client_id',
-            'sponsoring_client_id': 'sponsoring_client_id',
-            'update_client_id': 'update_client_id',
-            'update_date': 'update_date',
-            'name': 'name',
-            'organization': 'organization',
-            'street_1': 'street_1',
-            'street_2': 'street_2',
-            'street_3': 'street_3',
-            'city': 'city',
-            'province': 'province',
-            'postal_code': 'postal_code',
-            'country_code': 'country_code',
-            'phone': 'phone',
-            'fax': 'fax',
-            'email': 'email',
-            'password': '',
+            "id": "id",
+            "status": ["status1", "status2"],
+            "create_date": "create_date",
+            "creat_client_id": "creat_client_id",
+            "sponsoring_client_id": "sponsoring_client_id",
+            "update_client_id": "update_client_id",
+            "update_date": "update_date",
+            "name": "name",
+            "organization": "organization",
+            "street_1": "street_1",
+            "street_2": "street_2",
+            "street_3": "street_3",
+            "city": "city",
+            "province": "province",
+            "postal_code": "postal_code",
+            "country_code": "country_code",
+            "phone": "phone",
+            "fax": "fax",
+            "email": "email",
+            "password": "",
         }
 
         epp_communicator = MagicMock(EppCommunicator)
@@ -75,8 +76,8 @@ class ContactTest(unittest.TestCase):
 
     def test_data_to_dict_without_postal_info(self) -> None:
         data = ContactData(
-            id='id',
-            email='email',
+            id="id",
+            email="email",
             postal_info=None,
         )
 
@@ -86,238 +87,271 @@ class ContactTest(unittest.TestCase):
         result = contact._data_to_dict(data)
 
         expected_result = {
-            'id': 'id',
-            'status': None,
-            'create_date': '',
-            'creat_client_id': '',
-            'sponsoring_client_id': '',
-            'update_client_id': '',
-            'update_date': '',
-            'phone': '',
-            'fax': '',
-            'email': 'email',
-            'password': '',
+            "id": "id",
+            "status": None,
+            "create_date": "",
+            "creat_client_id": "",
+            "sponsoring_client_id": "",
+            "update_client_id": "",
+            "update_date": "",
+            "phone": "",
+            "fax": "",
+            "email": "email",
+            "password": "",
         }
         self.assertDictEqual(result, expected_result)
 
     def test_check_unsuccessful(self) -> None:
         epp_communicator = MagicMock(EppCommunicator)
         contact = Contact(epp_communicator)
-        expected_result = \
-            EppResultData(**{'code': 2000, 'message': "Command completed unsuccessfully",
-                             'reason': None, 'raw_response': "response", 'result_data': None})
+        expected_result = EppResultData(
+            **{
+                "code": 2000,
+                "message": "Command completed unsuccessfully",
+                "reason": None,
+                "raw_response": "response",
+                "result_data": None,
+            }
+        )
         contact.execute = MagicMock(return_value=expected_result)
 
-        result = contact.check(['contact1'])
+        result = contact.check(["contact1"])
 
         self.assertEqual(result, expected_result)
 
     def test_check(self) -> None:
         epp_communicator = MagicMock(EppCommunicator)
         contact = Contact(epp_communicator)
-        expected_result = EppResultData(**{
-            'client_transaction_id': 'eccb044f-a80f-4db3-a918-988f1ac918e3',
-            'code': 1000,
-            'message': 'Command completed successfully',
-            'raw_response': '<response>\n'
-                            '<result code="1000">\n'
-                            '<msg>Command completed successfully</msg>\n'
-                            '</result>\n'
-                            '<resData>\n'
-                            '<contact:chkData>\n'
-                            '<contact:cd>\n'
-                            '<contact:id avail="true">contact1</contact:id>\n'
-                            '</contact:cd>\n'
-                            '</contact:chkData>\n'
-                            '</resData>\n'
-                            '<trID>\n'
-                            '<clTRID>eccb044f-a80f-4db3-a918-988f1ac918e3</clTRID>\n'
-                            '<svTRID>CIRA-000062206323-0000000003</svTRID>\n'
-                            '</trID>\n'
-                            '</response>',
-            'reason': None,
-            'repository_object_id': None,
-            'result_data': {'contact1': {'avail': True, 'reason': None},
-                            'contact2': {'avail': False,
-                                         'reason': 'Selected contact ID is not '
-                                                   'available'}},
-            'server_transaction_id': 'CIRA-000062206323-0000000003'
-        })
+        expected_result = EppResultData(
+            **{
+                "client_transaction_id": "eccb044f-a80f-4db3-a918-988f1ac918e3",
+                "code": 1000,
+                "message": "Command completed successfully",
+                "raw_response": "<response>\n"
+                '<result code="1000">\n'
+                "<msg>Command completed successfully</msg>\n"
+                "</result>\n"
+                "<resData>\n"
+                "<contact:chkData>\n"
+                "<contact:cd>\n"
+                '<contact:id avail="true">contact1</contact:id>\n'
+                "</contact:cd>\n"
+                "</contact:chkData>\n"
+                "</resData>\n"
+                "<trID>\n"
+                "<clTRID>eccb044f-a80f-4db3-a918-988f1ac918e3</clTRID>\n"
+                "<svTRID>CIRA-000062206323-0000000003</svTRID>\n"
+                "</trID>\n"
+                "</response>",
+                "reason": None,
+                "repository_object_id": None,
+                "result_data": {
+                    "contact1": {"avail": True, "reason": None},
+                    "contact2": {
+                        "avail": False,
+                        "reason": "Selected contact ID is not " "available",
+                    },
+                },
+                "server_transaction_id": "CIRA-000062206323-0000000003",
+            }
+        )
 
         contact.execute = MagicMock(return_value=expected_result)
 
-        result = contact.check(['contact1', 'contact2'])
+        result = contact.check(["contact1", "contact2"])
 
         self.assertEqual(result, expected_result)
 
     def test_info_unsuccessful(self) -> None:
         epp_communicator = MagicMock(EppCommunicator)
         contact = Contact(epp_communicator)
-        expected_result = \
-            EppResultData(**{'code': 2000, 'message': "Command completed unsuccessfully",
-                             'reason': None, 'raw_response': "response", 'result_data': None})
+        expected_result = EppResultData(
+            **{
+                "code": 2000,
+                "message": "Command completed unsuccessfully",
+                "reason": None,
+                "raw_response": "response",
+                "result_data": None,
+            }
+        )
         contact.execute = MagicMock(return_value=expected_result)
 
-        result = contact.info('contact1')
+        result = contact.info("contact1")
 
         self.assertEqual(result, expected_result)
 
     def test_info(self) -> None:
         epp_communicator = MagicMock(EppCommunicator)
         contact = Contact(epp_communicator)
-        execute_result = EppResultData(**{
-            'client_transaction_id': '5123c3d4-79ce-4d87-ad7b-d234eb992474',
-            'code': 1000,
-            'message': 'Command completed successfully',
-            'raw_response': '<response>\n'
-                            '<result code="1000">\n'
-                            '<msg>Command completed successfully</msg>\n'
-                            '</result>\n'
-                            '<resData>\n'
-                            '<contact:infData>\n'
-                            '<contact:id>inz-contact-1</contact:id>\n'
-                            '<contact:roid>9175701-INZ</contact:roid>\n'
-                            '<contact:status s="linked"/>\n'
-                            '<contact:postalInfo type="loc">\n'
-                            '<contact:name>inz</contact:name>\n'
-                            '<contact:addr>\n'
-                            '<contact:street>18 portmore place</contact:street>\n'
-                            '<contact:city>Wellington</contact:city>\n'
-                            '<contact:cc>NZ</contact:cc>\n'
-                            '</contact:addr>\n'
-                            '</contact:postalInfo>\n'
-                            '<contact:email>inz@internet.net.nz</contact:email>\n'
-                            '<contact:clID>933</contact:clID>\n'
-                            '<contact:crID>933</contact:crID>\n'
-                            '<contact:crDate>2023-02-23T02:59:16.784Z</contact:crDate>\n'
-                            '<contact:upID>CIRA_RAR_1</contact:upID>\n'
-                            '<contact:upDate>2023-02-23T21:59:01.021Z</contact:upDate>\n'
-                            '<contact:authInfo>\n'
-                            '<contact:pw>PassWord</contact:pw>\n'
-                            '</contact:authInfo>\n'
-                            '</contact:infData>\n'
-                            '</resData>\n'
-                            '<trID>\n'
-                            '<clTRID>5123c3d4-79ce-4d87-ad7b-d234eb992474</clTRID>\n'
-                            '<svTRID>CIRA-000062211375-0000000003</svTRID>\n'
-                            '</trID>\n'
-                            '</response>',
-            'reason': None,
-            'repository_object_id': '9175701-INZ',
-            'server_transaction_id': 'CIRA-000062211375-0000000003',
-            'result_data': None
-        })
+        execute_result = EppResultData(
+            **{
+                "client_transaction_id": "5123c3d4-79ce-4d87-ad7b-d234eb992474",
+                "code": 1000,
+                "message": "Command completed successfully",
+                "raw_response": "<response>\n"
+                '<result code="1000">\n'
+                "<msg>Command completed successfully</msg>\n"
+                "</result>\n"
+                "<resData>\n"
+                "<contact:infData>\n"
+                "<contact:id>inz-contact-1</contact:id>\n"
+                "<contact:roid>9175701-INZ</contact:roid>\n"
+                '<contact:status s="linked"/>\n'
+                '<contact:postalInfo type="loc">\n'
+                "<contact:name>inz</contact:name>\n"
+                "<contact:addr>\n"
+                "<contact:street>18 test street</contact:street>\n"
+                "<contact:city>Wellington</contact:city>\n"
+                "<contact:cc>NZ</contact:cc>\n"
+                "</contact:addr>\n"
+                "</contact:postalInfo>\n"
+                "<contact:email>inz@internet.net.nz</contact:email>\n"
+                "<contact:clID>933</contact:clID>\n"
+                "<contact:crID>933</contact:crID>\n"
+                "<contact:crDate>2023-02-23T02:59:16.784Z</contact:crDate>\n"
+                "<contact:upID>CIRA_RAR_1</contact:upID>\n"
+                "<contact:upDate>2023-02-23T21:59:01.021Z</contact:upDate>\n"
+                "<contact:authInfo>\n"
+                "<contact:pw>PassWord</contact:pw>\n"
+                "</contact:authInfo>\n"
+                "</contact:infData>\n"
+                "</resData>\n"
+                "<trID>\n"
+                "<clTRID>5123c3d4-79ce-4d87-ad7b-d234eb992474</clTRID>\n"
+                "<svTRID>CIRA-000062211375-0000000003</svTRID>\n"
+                "</trID>\n"
+                "</response>",
+                "reason": None,
+                "repository_object_id": "9175701-INZ",
+                "server_transaction_id": "CIRA-000062211375-0000000003",
+                "result_data": None,
+            }
+        )
 
-        expected_result = EppResultData(**{
-            'client_transaction_id': '5123c3d4-79ce-4d87-ad7b-d234eb992474',
-            'code': 1000,
-            'message': 'Command completed successfully',
-            'raw_response': '<response>\n'
-                            '<result code="1000">\n'
-                            '<msg>Command completed successfully</msg>\n'
-                            '</result>\n'
-                            '<resData>\n'
-                            '<contact:infData>\n'
-                            '<contact:id>inz-contact-1</contact:id>\n'
-                            '<contact:roid>9175701-INZ</contact:roid>\n'
-                            '<contact:status s="linked"/>\n'
-                            '<contact:postalInfo type="loc">\n'
-                            '<contact:name>inz</contact:name>\n'
-                            '<contact:addr>\n'
-                            '<contact:street>18 portmore place</contact:street>\n'
-                            '<contact:city>Wellington</contact:city>\n'
-                            '<contact:cc>NZ</contact:cc>\n'
-                            '</contact:addr>\n'
-                            '</contact:postalInfo>\n'
-                            '<contact:email>inz@internet.net.nz</contact:email>\n'
-                            '<contact:clID>933</contact:clID>\n'
-                            '<contact:crID>933</contact:crID>\n'
-                            '<contact:crDate>2023-02-23T02:59:16.784Z</contact:crDate>\n'
-                            '<contact:upID>CIRA_RAR_1</contact:upID>\n'
-                            '<contact:upDate>2023-02-23T21:59:01.021Z</contact:upDate>\n'
-                            '<contact:authInfo>\n'
-                            '<contact:pw>PassWord</contact:pw>\n'
-                            '</contact:authInfo>\n'
-                            '</contact:infData>\n'
-                            '</resData>\n'
-                            '<trID>\n'
-                            '<clTRID>5123c3d4-79ce-4d87-ad7b-d234eb992474</clTRID>\n'
-                            '<svTRID>CIRA-000062211375-0000000003</svTRID>\n'
-                            '</trID>\n'
-                            '</response>',
-            'reason': None,
-            'repository_object_id': '9175701-INZ',
-            'result_data': ContactData(id='inz-contact-1',
-                                       email='inz@internet.net.nz',
-                                       postal_info=PostalInfoData(**{'address': AddressData(**{'city': 'Wellington',
-                                                                                               'country_code': 'NZ',
-                                                                                               'postal_code': None,
-                                                                                               'province': None,
-                                                                                               'street_1': '18 portmore '
-                                                                                                           'place',
-                                                                                               'street_2': None,
-                                                                                               'street_3': None}),
-                                                                     'name': 'inz',
-                                                                     'organization': None}),
-                                       status=[''],
-                                       phone=None,
-                                       fax=None,
-                                       password='PassWord',
-                                       create_date='2023-02-23T02:59:16.784Z',
-                                       creat_client_id='933',
-                                       sponsoring_client_id='933',
-                                       update_client_id='CIRA_RAR_1',
-                                       update_date='2023-02-23T21:59:01.021Z'
-                                       ),
-            'server_transaction_id': 'CIRA-000062211375-0000000003'
-        })
+        expected_result = EppResultData(
+            **{
+                "client_transaction_id": "5123c3d4-79ce-4d87-ad7b-d234eb992474",
+                "code": 1000,
+                "message": "Command completed successfully",
+                "raw_response": "<response>\n"
+                '<result code="1000">\n'
+                "<msg>Command completed successfully</msg>\n"
+                "</result>\n"
+                "<resData>\n"
+                "<contact:infData>\n"
+                "<contact:id>inz-contact-1</contact:id>\n"
+                "<contact:roid>9175701-INZ</contact:roid>\n"
+                '<contact:status s="linked"/>\n'
+                '<contact:postalInfo type="loc">\n'
+                "<contact:name>inz</contact:name>\n"
+                "<contact:addr>\n"
+                "<contact:street>18 test street</contact:street>\n"
+                "<contact:city>Wellington</contact:city>\n"
+                "<contact:cc>NZ</contact:cc>\n"
+                "</contact:addr>\n"
+                "</contact:postalInfo>\n"
+                "<contact:email>inz@internet.net.nz</contact:email>\n"
+                "<contact:clID>933</contact:clID>\n"
+                "<contact:crID>933</contact:crID>\n"
+                "<contact:crDate>2023-02-23T02:59:16.784Z</contact:crDate>\n"
+                "<contact:upID>CIRA_RAR_1</contact:upID>\n"
+                "<contact:upDate>2023-02-23T21:59:01.021Z</contact:upDate>\n"
+                "<contact:authInfo>\n"
+                "<contact:pw>PassWord</contact:pw>\n"
+                "</contact:authInfo>\n"
+                "</contact:infData>\n"
+                "</resData>\n"
+                "<trID>\n"
+                "<clTRID>5123c3d4-79ce-4d87-ad7b-d234eb992474</clTRID>\n"
+                "<svTRID>CIRA-000062211375-0000000003</svTRID>\n"
+                "</trID>\n"
+                "</response>",
+                "reason": None,
+                "repository_object_id": "9175701-INZ",
+                "result_data": ContactData(
+                    id="inz-contact-1",
+                    email="inz@internet.net.nz",
+                    postal_info=PostalInfoData(
+                        **{
+                            "address": AddressData(
+                                **{
+                                    "city": "Wellington",
+                                    "country_code": "NZ",
+                                    "postal_code": None,
+                                    "province": None,
+                                    "street_1": "18 test street",
+                                    "street_2": None,
+                                    "street_3": None,
+                                }
+                            ),
+                            "name": "inz",
+                            "organization": None,
+                        }
+                    ),
+                    status=[""],
+                    phone=None,
+                    fax=None,
+                    password="PassWord",
+                    create_date="2023-02-23T02:59:16.784Z",
+                    creat_client_id="933",
+                    sponsoring_client_id="933",
+                    update_client_id="CIRA_RAR_1",
+                    update_date="2023-02-23T21:59:01.021Z",
+                ),
+                "server_transaction_id": "CIRA-000062211375-0000000003",
+            }
+        )
 
         contact.execute = MagicMock(return_value=execute_result)
 
-        result = contact.info('inz-contact-1')
+        result = contact.info("inz-contact-1")
 
         self.assertEqual(result, expected_result)
 
     def test_create(self) -> None:
-        expected_result = EppResultData(**{'client_transaction_id': 'caae2895-fe01-4f1c-a892-115b17315acc',
-                                           'code': 1000,
-                                           'message': 'Command completed successfully',
-                                           'raw_response': '<response>\n'
-                                                           '<result code="1000">\n'
-                                                           '<msg>Command completed successfully</msg>\n'
-                                                           '</result>\n'
-                                                           '<resData>\n'
-                                                           '<contact:creData>\n'
-                                                           '<contact:id>inz-contact-1</contact:id>\n'
-                                                           '<contact:crDate>2023-04-26T23:06:11.894Z</contact:crDate>\n'
-                                                           '</contact:creData>\n'
-                                                           '</resData>\n'
-                                                           '<trID>\n'
-                                                           '<clTRID>caae2895-fe01-4f1c-a892-115b17315acc</clTRID>\n'
-                                                           '<svTRID>CIRA-000062214171-0000000003</svTRID>\n'
-                                                           '</trID>\n'
-                                                           '</response>',
-                                           'reason': None,
-                                           'repository_object_id': None,
-                                           'server_transaction_id': 'CIRA-000062214171-0000000003',
-                                           'result_data': None})
+        expected_result = EppResultData(
+            **{
+                "client_transaction_id": "caae2895-fe01-4f1c-a892-115b17315acc",
+                "code": 1000,
+                "message": "Command completed successfully",
+                "raw_response": "<response>\n"
+                '<result code="1000">\n'
+                "<msg>Command completed successfully</msg>\n"
+                "</result>\n"
+                "<resData>\n"
+                "<contact:creData>\n"
+                "<contact:id>inz-contact-1</contact:id>\n"
+                "<contact:crDate>2023-04-26T23:06:11.894Z</contact:crDate>\n"
+                "</contact:creData>\n"
+                "</resData>\n"
+                "<trID>\n"
+                "<clTRID>caae2895-fe01-4f1c-a892-115b17315acc</clTRID>\n"
+                "<svTRID>CIRA-000062214171-0000000003</svTRID>\n"
+                "</trID>\n"
+                "</response>",
+                "reason": None,
+                "repository_object_id": None,
+                "server_transaction_id": "CIRA-000062214171-0000000003",
+                "result_data": None,
+            }
+        )
 
         create_params = ContactData(
-            id='inz-contact-1',
-            email='epp@internetnz.net.nz',
+            id="inz-contact-1",
+            email="epp@internetnz.net.nz",
             postal_info=PostalInfoData(
-                name='IRS EPP',
-                organization='INZ',
+                name="IRS EPP",
+                organization="INZ",
                 address=AddressData(
-                    street_1='18 Willis Street',
-                    street_2='Wellington CBD',
-                    city='Wellington',
-                    country_code='NZ',
-                    province='Wellington',
-                    postal_code='6011'
+                    street_1="18 test street",
+                    street_2="Wellington CBD",
+                    city="Wellington",
+                    country_code="NZ",
+                    province="Wellington",
+                    postal_code="6011",
                 ),
             ),
-            phone='+64.111111111'
+            phone="+64.111111111",
         )
 
         epp_communicator = MagicMock(EppCommunicator)
@@ -329,54 +363,62 @@ class ContactTest(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
     def test_delete(self) -> None:
-        expected_result = EppResultData(**{'client_transaction_id': 'a21a659d-5040-4848-9f5f-0cffa0ff62d1',
-                                           'code': 1000,
-                                           'message': 'Command completed successfully',
-                                           'raw_response': '<response>\n'
-                                                           '<result code="1000">\n'
-                                                           '<msg>Command completed successfully</msg>\n'
-                                                           '</result>\n'
-                                                           '<trID>\n'
-                                                           '<clTRID>a21a659d-5040-4848-9f5f-0cffa0ff62d1</clTRID>\n'
-                                                           '<svTRID>CIRA-000062220522-0000000004</svTRID>\n'
-                                                           '</trID>\n'
-                                                           '</response>',
-                                           'reason': None,
-                                           'repository_object_id': None,
-                                           'server_transaction_id': 'CIRA-000062220522-0000000004',
-                                           'result_data': None})
+        expected_result = EppResultData(
+            **{
+                "client_transaction_id": "a21a659d-5040-4848-9f5f-0cffa0ff62d1",
+                "code": 1000,
+                "message": "Command completed successfully",
+                "raw_response": "<response>\n"
+                '<result code="1000">\n'
+                "<msg>Command completed successfully</msg>\n"
+                "</result>\n"
+                "<trID>\n"
+                "<clTRID>a21a659d-5040-4848-9f5f-0cffa0ff62d1</clTRID>\n"
+                "<svTRID>CIRA-000062220522-0000000004</svTRID>\n"
+                "</trID>\n"
+                "</response>",
+                "reason": None,
+                "repository_object_id": None,
+                "server_transaction_id": "CIRA-000062220522-0000000004",
+                "result_data": None,
+            }
+        )
 
         epp_communicator = MagicMock(EppCommunicator)
         contact = Contact(epp_communicator)
         contact.execute = MagicMock(return_value=expected_result)
 
-        result = contact.delete('inz-contact-1')
+        result = contact.delete("inz-contact-1")
 
         self.assertEqual(result, expected_result)
 
     def test_update(self) -> None:
         update_params = ContactData(
-            id='inz-contact-1',
-            email='ehsan@internetnz.net.nz',
-            postal_info=PostalInfoData(name='IRS EPP2')
+            id="inz-contact-1",
+            email="ehsan@internetnz.net.nz",
+            postal_info=PostalInfoData(name="IRS EPP2"),
         )
 
-        expected_result = EppResultData(**{'client_transaction_id': '0e872842-b77b-4800-9572-c72e46e068de',
-                                           'code': 1000,
-                                           'message': 'Command completed successfully',
-                                           'raw_response': '<response>\n'
-                                                           '<result code="1000">\n'
-                                                           '<msg>Command completed successfully</msg>\n'
-                                                           '</result>\n'
-                                                           '<trID>\n'
-                                                           '<clTRID>0e872842-b77b-4800-9572-c72e46e068de</clTRID>\n'
-                                                           '<svTRID>CIRA-000062223355-0000000004</svTRID>\n'
-                                                           '</trID>\n'
-                                                           '</response>',
-                                           'reason': None,
-                                           'repository_object_id': None,
-                                           'server_transaction_id': 'CIRA-000062223355-0000000004',
-                                           'result_data': None})
+        expected_result = EppResultData(
+            **{
+                "client_transaction_id": "0e872842-b77b-4800-9572-c72e46e068de",
+                "code": 1000,
+                "message": "Command completed successfully",
+                "raw_response": "<response>\n"
+                '<result code="1000">\n'
+                "<msg>Command completed successfully</msg>\n"
+                "</result>\n"
+                "<trID>\n"
+                "<clTRID>0e872842-b77b-4800-9572-c72e46e068de</clTRID>\n"
+                "<svTRID>CIRA-000062223355-0000000004</svTRID>\n"
+                "</trID>\n"
+                "</response>",
+                "reason": None,
+                "repository_object_id": None,
+                "server_transaction_id": "CIRA-000062223355-0000000004",
+                "result_data": None,
+            }
+        )
 
         epp_communicator = MagicMock(EppCommunicator)
         contact = Contact(epp_communicator)
@@ -385,33 +427,37 @@ class ContactTest(unittest.TestCase):
         result = contact.update(update_params)
 
         _, call_kwargs = contact.execute.call_args
-        self.assertTrue(call_kwargs['postalinfo_change'])
+        self.assertTrue(call_kwargs["postalinfo_change"])
         self.assertEqual(result, expected_result)
 
     def test_update_without_postal_info(self) -> None:
         """Regression test: update() must not raise AttributeError when postal_info=None."""
         update_params = ContactData(
-            id='inz-contact-1',
-            email='ehsan@internetnz.net.nz',
+            id="inz-contact-1",
+            email="ehsan@internetnz.net.nz",
             postal_info=None,
         )
 
-        expected_result = EppResultData(**{'client_transaction_id': '0e872842-b77b-4800-9572-c72e46e068d2',
-                                           'code': 1000,
-                                           'message': 'Command completed successfully',
-                                           'raw_response': '<response>\n'
-                                                           '<result code="1000">\n'
-                                                           '<msg>Command completed successfully</msg>\n'
-                                                           '</result>\n'
-                                                           '<trID>\n'
-                                                           '<clTRID>0e872842-b77b-4800-9572-c72e46e068d2</clTRID>\n'
-                                                           '<svTRID>CIRA-000062223355-0000000004</svTRID>\n'
-                                                           '</trID>\n'
-                                                           '</response>',
-                                           'reason': None,
-                                           'repository_object_id': None,
-                                           'server_transaction_id': 'CIRA-000062223355-0000000004',
-                                           'result_data': None})
+        expected_result = EppResultData(
+            **{
+                "client_transaction_id": "0e872842-b77b-4800-9572-c72e46e068d2",
+                "code": 1000,
+                "message": "Command completed successfully",
+                "raw_response": "<response>\n"
+                '<result code="1000">\n'
+                "<msg>Command completed successfully</msg>\n"
+                "</result>\n"
+                "<trID>\n"
+                "<clTRID>0e872842-b77b-4800-9572-c72e46e068d2</clTRID>\n"
+                "<svTRID>CIRA-000062223355-0000000004</svTRID>\n"
+                "</trID>\n"
+                "</response>",
+                "reason": None,
+                "repository_object_id": None,
+                "server_transaction_id": "CIRA-000062223355-0000000004",
+                "result_data": None,
+            }
+        )
 
         epp_communicator = MagicMock(EppCommunicator)
         contact = Contact(epp_communicator)
@@ -420,51 +466,152 @@ class ContactTest(unittest.TestCase):
         result = contact.update(update_params)
 
         _, call_kwargs = contact.execute.call_args
-        self.assertFalse(call_kwargs['postalinfo_change'])
+        self.assertFalse(call_kwargs["postalinfo_change"])
         self.assertEqual(result, expected_result)
 
     def test_create_generates_password_when_not_supplied(self) -> None:
         """contact.create() must auto-generate a password when none is provided."""
         create_params = ContactData(
-            id='inz-contact-1',
-            email='epp@internetnz.net.nz',
+            id="inz-contact-1",
+            email="epp@internetnz.net.nz",
             postal_info=PostalInfoData(
-                name='IRS EPP',
+                name="IRS EPP",
                 address=AddressData(
-                    street_1='18 Willis Street',
-                    city='Wellington',
-                    country_code='NZ',
+                    street_1="18 test street",
+                    city="Wellington",
+                    country_code="NZ",
                 ),
             ),
         )
 
         epp_communicator = MagicMock(EppCommunicator)
         contact = Contact(epp_communicator)
-        contact.execute = MagicMock(return_value=EppResultData(
-            code=1000, message='Command completed successfully', raw_response='', result_data=None
-        ))
+        contact.execute = MagicMock(
+            return_value=EppResultData(
+                code=1000,
+                message="Command completed successfully",
+                raw_response="",
+                result_data=None,
+            )
+        )
 
         contact.create(create_params)
 
         _, kwargs = contact.execute.call_args
-        self.assertIn('password', kwargs)
-        self.assertTrue(kwargs['password'], "Password should be a non-empty generated string")
+        self.assertIn("password", kwargs)
+        self.assertTrue(
+            kwargs["password"], "Password should be a non-empty generated string"
+        )
 
     def test_update_does_not_generate_password_when_not_supplied(self) -> None:
         """contact.update() must NOT generate or include a password when none is provided."""
         update_params = ContactData(
-            id='inz-contact-1',
-            email='epp@internetnz.net.nz',
-            postal_info=PostalInfoData(name='IRS EPP2')
+            id="inz-contact-1",
+            email="epp@internetnz.net.nz",
+            postal_info=PostalInfoData(name="IRS EPP2"),
         )
 
         epp_communicator = MagicMock(EppCommunicator)
         contact = Contact(epp_communicator)
-        contact.execute = MagicMock(return_value=EppResultData(
-            code=1000, message='Command completed successfully', raw_response='', result_data=None
-        ))
+        contact.execute = MagicMock(
+            return_value=EppResultData(
+                code=1000,
+                message="Command completed successfully",
+                raw_response="",
+                result_data=None,
+            )
+        )
 
         contact.update(update_params)
 
         _, kwargs = contact.execute.call_args
-        self.assertFalse(kwargs.get('password'), "Password should not be set when not supplied to update()")
+        self.assertFalse(
+            kwargs.get("password"),
+            "Password should not be set when not supplied to update()",
+        )
+
+    def test_create_with_explicit_password(self) -> None:
+        """contact.create() must use the explicit password when provided, not generate one."""
+        create_params = ContactData(
+            id="inz-contact-1",
+            email="epp@internetnz.net.nz",
+            postal_info=PostalInfoData(
+                name="IRS EPP",
+                address=AddressData(
+                    street_1="Willis Street",
+                    city="Wellington",
+                    country_code="NZ",
+                ),
+            ),
+            password="MyExplicitPassword123",
+        )
+
+        epp_communicator = MagicMock(EppCommunicator)
+        contact = Contact(epp_communicator)
+        contact.execute = MagicMock(
+            return_value=EppResultData(
+                code=1000,
+                message="Command completed successfully",
+                raw_response="",
+                result_data=None,
+            )
+        )
+
+        contact.create(create_params)
+
+        _, kwargs = contact.execute.call_args
+        self.assertEqual(
+            kwargs["password"],
+            "MyExplicitPassword123",
+            "Explicit password should be used",
+        )
+
+    def test_info_without_password(self) -> None:
+        """contact.info() must handle response when no <contact:pw> node is present."""
+        epp_communicator = MagicMock(EppCommunicator)
+        contact = Contact(epp_communicator)
+        execute_result = EppResultData(
+            **{
+                "client_transaction_id": "5123c3d4-79ce-4d87-ad7b-d234eb992474",
+                "code": 1000,
+                "message": "Command completed successfully",
+                "raw_response": "<response>\n"
+                '<result code="1000">\n'
+                "<msg>Command completed successfully</msg>\n"
+                "</result>\n"
+                "<resData>\n"
+                "<contact:infData>\n"
+                "<contact:id>inz-contact-1</contact:id>\n"
+                "<contact:roid>9175701-INZ</contact:roid>\n"
+                '<contact:status s="linked"/>\n'
+                '<contact:postalInfo type="loc">\n'
+                "<contact:name>inz</contact:name>\n"
+                "<contact:addr>\n"
+                "<contact:street>Test street</contact:street>\n"
+                "<contact:city>Wellington</contact:city>\n"
+                "<contact:cc>NZ</contact:cc>\n"
+                "</contact:addr>\n"
+                "</contact:postalInfo>\n"
+                "<contact:email>inz@internet.net.nz</contact:email>\n"
+                "<contact:clID>933</contact:clID>\n"
+                "<contact:crID>933</contact:crID>\n"
+                "<contact:crDate>2023-02-23T02:59:16.784Z</contact:crDate>\n"
+                "<contact:upID>CIRA_RAR_1</contact:upID>\n"
+                "<contact:upDate>2023-02-23T21:59:01.021Z</contact:upDate>\n"
+                "</contact:infData>\n"
+                "</resData>\n"
+                "<trID>\n"
+                "<clTRID>5123c3d4-79ce-4d87-ad7b-d234eb992474</clTRID>\n"
+                "<svTRID>CIRA-000062211375-0000000003</svTRID>\n"
+                "</trID>\n"
+                "</response>",
+                "reason": None,
+                "repository_object_id": "9175701-INZ",
+                "server_transaction_id": "CIRA-000062211375-0000000003",
+                "result_data": None,
+            }
+        )
+
+        contact.execute = MagicMock(return_value=execute_result)
+        result = contact.info("inz-contact-1")
+        self.assertEqual(result.result_data.password, "")

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -672,3 +672,124 @@ class DomainTest(unittest.TestCase):
 
         _, kwargs = domain.execute.call_args
         self.assertFalse(kwargs.get("password"), "Password should not be set when not supplied to update()")
+
+    def test_create_renders_dns_sec_single(self) -> None:
+        """domain.create() must render a single dns_sec record correctly."""
+        dns_sec = DSRecordData(
+            key_tag=1235,
+            algorithm=DNSSECAlgorithm.DSA_SHA_1.value,
+            digest_type=DigestTypeEnum.SHA_1.value,
+            digest="8cdb09364147aed879d12c68d615f98af5900b73",
+        )
+        create_params = DomainData(
+            domain_name="internet.nz",
+            registrant="inz-contact-3",
+            dns_sec=dns_sec,
+        )
+
+        epp_communicator = MagicMock(EppCommunicator)
+        domain = Domain(epp_communicator)
+        domain.create(create_params)
+
+        # Access the rendered XML from the call to epp_communicator.execute
+        xml_command = epp_communicator.execute.call_args[0][0]
+        self.assertIn("<secDNS:keyTag>1235</secDNS:keyTag>", xml_command)
+        self.assertIn("<secDNS:alg>3</secDNS:alg>", xml_command)
+        self.assertEqual(xml_command.count("<secDNS:dsData>"), 1)
+
+    def test_create_renders_dns_sec_list(self) -> None:
+        """domain.create() must render a list of dns_sec records correctly."""
+        dns_sec = [
+            DSRecordData(
+                key_tag=1235,
+                algorithm=DNSSECAlgorithm.DSA_SHA_1.value,
+                digest_type=DigestTypeEnum.SHA_1.value,
+                digest="digest1",
+            ),
+            DSRecordData(
+                key_tag=5678,
+                algorithm=DNSSECAlgorithm.RSA_SHA_256.value,
+                digest_type=DigestTypeEnum.SHA_256.value,
+                digest="digest2",
+            )
+        ]
+        create_params = DomainData(
+            domain_name="internet.nz",
+            registrant="inz-contact-3",
+            dns_sec=dns_sec,
+        )
+
+        epp_communicator = MagicMock(EppCommunicator)
+        domain = Domain(epp_communicator)
+        domain.create(create_params)
+
+        # Access the rendered XML from the call to epp_communicator.execute
+        xml_command = epp_communicator.execute.call_args[0][0]
+        self.assertIn("<secDNS:keyTag>1235</secDNS:keyTag>", xml_command)
+        self.assertIn("<secDNS:keyTag>5678</secDNS:keyTag>", xml_command)
+        self.assertEqual(xml_command.count("<secDNS:dsData>"), 2)
+
+    def test_create_with_explicit_password(self) -> None:
+        """domain.create() must use the explicit password when provided."""
+        create_params = DomainData(
+            domain_name="internet.nz",
+            registrant="inz-contact-3",
+            password="MyExplicitPassword"
+        )
+
+        epp_communicator = MagicMock(EppCommunicator)
+        domain = Domain(epp_communicator)
+        domain.execute = MagicMock(return_value=EppResultData(
+            code=1000, message="Command completed successfully", raw_response="", result_data=None
+        ))
+
+        domain.create(create_params)
+
+        _, kwargs = domain.execute.call_args
+        self.assertEqual(kwargs["password"], "MyExplicitPassword")
+
+    def test_info_without_dns_sec(self) -> None:
+        """domain.info() must handle response when no <secDNS:infData> node is present."""
+        epp_communicator = MagicMock(EppCommunicator)
+        domain = Domain(epp_communicator)
+        execute_result = EppResultData(
+            **{
+                "client_transaction_id": None,
+                "code": 1000,
+                "message": "Command completed successfully",
+                "raw_response": "<response>\n"
+                '<result code="1000">\n'
+                "<msg>Command completed successfully</msg>\n"
+                "</result>\n"
+                "<resData>\n"
+                "<domain:infData>\n"
+                "<domain:name>internet.nz</domain:name>\n"
+                "<domain:roid>9204701-INZ</domain:roid>\n"
+                '<domain:status s="inactive"/>\n'
+                "<domain:registrant>inz-contact-1</domain:registrant>\n"
+                "<domain:contact "
+                'type="admin">inz-contact-1</domain:contact>\n'
+                "<domain:contact "
+                'type="tech">inz-contact-1</domain:contact>\n'
+                "<domain:clID>933</domain:clID>\n"
+                "<domain:crID>933</domain:crID>\n"
+                "<domain:crDate>2023-02-23T21:56:22.713Z</domain:crDate>\n"
+                "<domain:upID>CIRA_RAR_1</domain:upID>\n"
+                "<domain:upDate>2023-02-24T21:59:27.901Z</domain:upDate>\n"
+                "<domain:exDate>2024-02-23T21:56:22.713Z</domain:exDate>\n"
+                "</domain:infData>\n"
+                "</resData>\n"
+                "<trID>\n"
+                "<svTRID>CIRA-000063163743-0000000003</svTRID>\n"
+                "</trID>\n"
+                "</response>",
+                "reason": None,
+                "repository_object_id": "9204701-INZ",
+                "server_transaction_id": "CIRA-000063163743-0000000003",
+                "result_data": None,
+            }
+        )
+
+        domain.execute = MagicMock(return_value=execute_result)
+        result = domain.info("internet.nz")
+        self.assertIsNone(result.result_data.dns_sec)

--- a/tests/test_epp.py
+++ b/tests/test_epp.py
@@ -1,0 +1,130 @@
+"""
+EPP Communicator unit tests
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import struct
+import socket
+
+from pyepp.epp import EppCommunicator, EppResultData, EppCommunicatorException
+
+class EppResultDataTest(unittest.TestCase):
+    def test_dunder_methods_and_to_dict(self):
+        data = EppResultData(code=1000, message='Success', raw_response='raw', result_data=None)
+        # test __setitem__
+        data['reason'] = 'No reason'
+        # test __getitem__
+        self.assertEqual(data['reason'], 'No reason')
+        # test __len__
+        self.assertTrue(len(data) > 3)
+        # test to_dict
+        d = data.to_dict()
+        self.assertEqual(d['code'], 1000)
+        self.assertEqual(d['message'], 'Success')
+
+
+class EppCommunicatorTest(unittest.TestCase):
+    def setUp(self):
+        self.epp = EppCommunicator('localhost', '700', dry_run=False)
+
+    @patch('pyepp.epp.sys.exit')
+    def test_execute_command_dry_run(self, mock_exit):
+        mock_exit.side_effect = SystemExit
+        self.epp._dry_run = True
+        with self.assertRaises(SystemExit):
+            self.epp._execute_command("test")
+        mock_exit.assert_called_once()
+
+    def test_read_empty_length(self):
+        self.epp._ssl_socket = MagicMock()
+        self.epp._ssl_socket.read.return_value = b''
+        result = self.epp._read()
+        self.assertIsNone(result)
+
+    def test_execute_command_no_response(self):
+        self.epp._write = MagicMock()
+        self.epp._read = MagicMock(return_value=None)
+        with self.assertRaises(EppCommunicatorException) as context:
+            self.epp._execute_command("test")
+        self.assertIn("Cannot connect to server. Please re-login!", str(context.exception))
+
+    @patch('pyepp.epp.ssl.create_default_context')
+    def test_connect_exception(self, mock_ssl):
+        mock_ssl.side_effect = Exception("SSL Error")
+        with self.assertRaises(EppCommunicatorException) as context:
+            self.epp.connect()
+        self.assertIn("Could not setup a sec sure connection", str(context.exception))
+
+    def test_execute_not_connected(self):
+        self.epp.greeting = None
+        self.epp._dry_run = False
+        with self.assertRaises(EppCommunicatorException) as context:
+            self.epp.execute("<xml/>")
+        self.assertIn("The connection to the server has not been established yet!", str(context.exception))
+
+    @patch('pyepp.epp.BeautifulSoup')
+    def test_execute_attribute_error_missing_code(self, mock_bs):
+        self.epp.greeting = b'greeting'
+        self.epp._execute_command = MagicMock(return_value='xml')
+        mock_xml = MagicMock()
+        mock_result = MagicMock()
+        mock_result.get.side_effect = AttributeError("Mock attribute error")
+        mock_xml.find.side_effect = lambda tag, *args, **kwargs: mock_result if tag == "result" else MagicMock()
+        mock_bs.return_value = mock_xml
+        with self.assertRaises(EppCommunicatorException) as context:
+            self.epp.execute("<xml/>")
+        self.assertIn("Could not get result code.", str(context.exception))
+
+    def test_execute_generic_exception(self):
+        self.epp.greeting = b'greeting'
+        self.epp._execute_command = MagicMock(side_effect=ValueError("Some value error"))
+        with self.assertRaises(EppCommunicatorException) as context:
+            self.epp.execute("<xml/>")
+        self.assertIn("Some value error", str(context.exception))
+
+    @patch('pyepp.epp.EppCommunicator.execute')
+    def test_login_no_extensions(self, mock_execute):
+        mock_result = MagicMock()
+        mock_result.code = 1000
+        mock_execute.return_value = mock_result
+
+        # Call without extensions to hit `if extensions is None: extensions = []`
+        result = self.epp.login('user', 'pass')
+        self.assertEqual(result.code, 1000)
+        self.assertEqual(self.epp.user, 'user')
+
+    @patch('pyepp.epp.EppCommunicator.execute')
+    def test_login_with_extensions(self, mock_execute):
+        mock_result = MagicMock()
+        mock_result.code = 1000
+        mock_execute.return_value = mock_result
+        self.epp.login('user', 'pass', extensions=['urn:ietf:params:xml:ns:secDNS-1.1'])
+        self.assertEqual(self.epp.user, 'user')
+
+    @patch('pyepp.epp.ssl.create_default_context')
+    def test_connect_with_cert_and_key(self, mock_ssl):
+        epp = EppCommunicator('localhost', '700', client_cert='cert.pem', client_key='key.pem', dry_run=False)
+        mock_context = MagicMock()
+        mock_ssl.return_value = mock_context
+        epp._read = MagicMock(return_value=b'greeting')
+        epp.connect()
+        mock_context.load_cert_chain.assert_called_with(certfile='cert.pem', keyfile='key.pem')
+
+    @patch('pyepp.epp.ssl.create_default_context')
+    def test_connect_without_cert_and_key(self, mock_ssl):
+        epp = EppCommunicator('localhost', '700', dry_run=False)
+        mock_context = MagicMock()
+        mock_ssl.return_value = mock_context
+        epp._read = MagicMock(return_value=b'greeting')
+        epp.connect()
+        mock_context.load_cert_chain.assert_not_called()
+
+    def test_read_empty_chunk(self):
+        self.epp._ssl_socket = MagicMock()
+        # Mock length to something that decodes to total_bytes > LENGTH_FIELD_SIZE (4)
+        # Using format ">I" means big-endian unsigned int. 8 means length 8.
+        self.epp._ssl_socket.read.return_value = struct.pack(">I", 8)
+        self.epp._ssl_socket.recv.return_value = b''
+        result = self.epp._read()
+        self.assertIsNone(result)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,4 +1,14 @@
 """
-
+Helper unit tests
 """
+import unittest
 
+from pyepp import helper
+
+
+class HelperTest(unittest.TestCase):
+    def test_beautify_xml(self) -> None:
+        xml_content = b"<test><node>1</node></test>"
+        result = helper.xml_pretty(xml_content)
+        self.assertIn("<?xml version=\"1.0\" encoding=\"utf-8\"?>", result)
+        self.assertIn("<test>\n", result)

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -1,6 +1,7 @@
 """
 Host Name Mapping unit tests
 """
+
 import unittest
 from datetime import date
 from unittest.mock import MagicMock
@@ -20,9 +21,15 @@ class HostTest(unittest.TestCase):
     def test_poll_request_unsuccessful(self) -> None:
         epp_communicator = MagicMock(EppCommunicator)
         poll = Poll(epp_communicator)
-        expected_result = \
-            EppResultData(**{'code': 2000, 'message': "Command completed unsuccessfully",
-                             'reason': None, 'raw_response': "response", 'result_data': None})
+        expected_result = EppResultData(
+            **{
+                "code": 2000,
+                "message": "Command completed unsuccessfully",
+                "reason": None,
+                "raw_response": "response",
+                "result_data": None,
+            }
+        )
         poll.execute = MagicMock(return_value=expected_result)
 
         result = poll.request()
@@ -32,36 +39,45 @@ class HostTest(unittest.TestCase):
     def test_poll_request(self) -> None:
         epp_communicator = MagicMock(EppCommunicator)
         poll = Poll(epp_communicator)
-        expected_result = \
-            EppResultData(**{'client_transaction_id': 'c6710aac-cbcf-48d0-9ec3-cfaad1cadc81',
-                             'code': 1301,
-                             'message': 'Command completed successfully; ack to dequeue',
-                             'raw_response': '<response>\n'
-                                             '<result code="1301">\n'
-                                             '<msg>Command completed successfully; ack to dequeue</msg>\n'
-                                             '</result>\n'
-                                             '<msgQ count="1" id="27690316">\n'
-                                             '<qDate>2023-07-26T00:21:31.246Z</qDate>\n'
-                                             '<msg lang="en">Contact inz-contact-1 has been '
-                                             'deleted.</msg>\n'
-                                             '</msgQ>\n'
-                                             '<trID>\n'
-                                             '<clTRID>c6710aac-cbcf-48d0-9ec3-cfaad1cadc81</clTRID>\n'
-                                             '<svTRID>CIRA-000097025501-0000000002</svTRID>\n'
-                                             '</trID>\n'
-                                             '</response>',
-                             'reason': None,
-                             'repository_object_id': None,
-                             'result_data': ServiceMessageQueueData(message_count='1',
-                                                                    message_id='27690316',
-                                                                    queue_date='2023-07-26T00:21:31.246Z',
-                                                                    messages=[ServiceMessageData(language='en',
-                                                                                                 message='Contact '
-                                                                                                         'inz-contact-1 '
-                                                                                                         'has '
-                                                                                                         'been '
-                                                                                                         'deleted.')]),
-                             'server_transaction_id': 'CIRA-000097025501-0000000002'})
+        expected_result = EppResultData(
+            **{
+                "client_transaction_id": "c6710aac-cbcf-48d0-9ec3-cfaad1cadc81",
+                "code": 1301,
+                "message": "Command completed successfully; ack to dequeue",
+                "raw_response": "<response>\n"
+                '<result code="1301">\n'
+                "<msg>Command completed successfully; ack to dequeue</msg>\n"
+                "</result>\n"
+                '<msgQ count="1" id="27690316">\n'
+                "<qDate>2023-07-26T00:21:31.246Z</qDate>\n"
+                '<msg lang="en">Contact inz-contact-1 has been '
+                "deleted.</msg>\n"
+                "</msgQ>\n"
+                "<trID>\n"
+                "<clTRID>c6710aac-cbcf-48d0-9ec3-cfaad1cadc81</clTRID>\n"
+                "<svTRID>CIRA-000097025501-0000000002</svTRID>\n"
+                "</trID>\n"
+                "</response>",
+                "reason": None,
+                "repository_object_id": None,
+                "result_data": ServiceMessageQueueData(
+                    message_count="1",
+                    message_id="27690316",
+                    queue_date="2023-07-26T00:21:31.246Z",
+                    messages=[
+                        ServiceMessageData(
+                            language="en",
+                            message="Contact "
+                            "inz-contact-1 "
+                            "has "
+                            "been "
+                            "deleted.",
+                        )
+                    ],
+                ),
+                "server_transaction_id": "CIRA-000097025501-0000000002",
+            }
+        )
 
         poll.execute = MagicMock(return_value=expected_result)
 
@@ -72,9 +88,15 @@ class HostTest(unittest.TestCase):
     def test_poll_ack_unsuccessful(self) -> None:
         epp_communicator = MagicMock(EppCommunicator)
         poll = Poll(epp_communicator)
-        expected_result = \
-            EppResultData(**{'code': 1500, 'message': "Command completed successfully",
-                             'reason': None, 'raw_response': "response", 'result_data': None})
+        expected_result = EppResultData(
+            **{
+                "code": 1500,
+                "message": "Command completed successfully",
+                "reason": None,
+                "raw_response": "response",
+                "result_data": None,
+            }
+        )
         poll.execute = MagicMock(return_value=expected_result)
 
         result = poll.acknowledge(121212)
@@ -84,28 +106,54 @@ class HostTest(unittest.TestCase):
     def test_poll_ack(self) -> None:
         epp_communicator = MagicMock(EppCommunicator)
         poll = Poll(epp_communicator)
-        expected_result = \
-            EppResultData(**{'client_transaction_id': 'c6710aac-cbcf-48d0-9ec3-cfaad1cadc81',
-                             'code': 1301,
-                             'message': 'Command completed successfully',
-                             'raw_response': '<response>\n'
-                                             '<result code="1000">\n'
-                                             '<msg>Command completed successfully</msg>\n'
-                                             '</result>\n'
-                                             '<msgQ count="1" id="27690316">\n'
-                                             '</msgQ>\n'
-                                             '<trID>\n'
-                                             '<clTRID>c6710aac-cbcf-48d0-9ec3-cfaad1cadc81</clTRID>\n'
-                                             '<svTRID>CIRA-000097025501-0000000002</svTRID>\n'
-                                             '</trID>\n'
-                                             '</response>',
-                             'reason': None,
-                             'repository_object_id': None,
-                             'result_data': None,
-                             'server_transaction_id': 'CIRA-000097025501-0000000002'})
+
+        expected_result = EppResultData(
+            **{
+                "client_transaction_id": "c6710aac-cbcf-48d0-9ec3-cfaad1cadc81",
+                "code": 1000,
+                "message": "Command completed successfully",
+                "raw_response": "<response>\n"
+                '<result code="1000">\n'
+                "<msg>Command completed successfully</msg>\n"
+                "</result>\n"
+                '<msgQ count="1" id="27690316">\n'
+                "</msgQ>\n"
+                "<trID>\n"
+                "<clTRID>c6710aac-cbcf-48d0-9ec3-cfaad1cadc81</clTRID>\n"
+                "<svTRID>CIRA-000097025501-0000000002</svTRID>\n"
+                "</trID>\n"
+                "</response>",
+                "reason": None,
+                "repository_object_id": None,
+                "result_data": None,
+                "server_transaction_id": "CIRA-000097025501-0000000002",
+            }
+        )
 
         poll.execute = MagicMock(return_value=expected_result)
 
         result = poll.acknowledge(27690316)
 
-        self.assertEqual(result, expected_result)
+        self.assertEqual(result.code, 1000)
+        self.assertEqual(result.result_data.message_count, 1)
+        self.assertEqual(result.result_data.message_id, 27690316)
+
+    def test_data_to_dict(self) -> None:
+        epp_communicator = MagicMock(EppCommunicator)
+        poll = Poll(epp_communicator)
+        data = ServiceMessageQueueData(
+            message_count=1,
+            message_id=123,
+            queue_date="2023-01-01T00:00:00.000Z",
+            messages=[ServiceMessageData(language="en", message="Test msg")],
+        )
+        result = poll._data_to_dict(data)
+        self.assertDictEqual(
+            result,
+            {
+                "message_count": 1,
+                "message_id": 123,
+                "queue_date": "2023-01-01T00:00:00.000Z",
+                "messages": [{"language": "en", "message": "Test msg"}],
+            },
+        )

--- a/tests/test_pyepp.py
+++ b/tests/test_pyepp.py
@@ -170,13 +170,12 @@ class PyEPPTests(unittest.TestCase):
     def test_write(self) -> None:
         epp = EppCommunicator(**self.epp_config)
         expected_result = 103
-        epp._ssl_socket = MagicMock(
-            send=MagicMock(return_value=expected_result),
-        )
+        epp._ssl_socket = MagicMock()
 
         result = epp._write(HELLO_XML)
 
         self.assertEqual(result, expected_result)
+        self.assertEqual(epp._ssl_socket.sendall.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the PyEPP codebase, focusing on enhanced DNSSEC handling, improved template rendering, better falsy value support, and documentation updates. The changes ensure more robust and flexible EPP command generation, especially for DNSSEC data, and improve the reliability of socket communications. Additionally, the CLI and documentation have been updated for clarity and accuracy.

**DNSSEC and Command Rendering Improvements**
* Updated the domain creation template and logic to support both single and multiple DNSSEC (`dns_sec`) records, allowing a list of DS records to be rendered correctly in the EPP XML. This is now thoroughly tested with new unit tests for both single and multiple `dns_sec` scenarios. [[1]](diffhunk://#diff-fff29c610d0a0f1ee901007ee2b25bb25ec00ce7681a0a5f0bcf648dc6435daeR246-R266) [[2]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L89-R95) [[3]](diffhunk://#diff-446287dd45b2b67205882e7bf7f0fe5b22af68529704d8ae06068845a400e7ceR675-R795)
* Fixed a typo in the domain transfer template (`command_templates.py`) where the closing tag for `domain:pw` was incorrect.

**Falsy Value Handling**
* Modified the base command logic to preserve falsy values like `0` and `False` in command parameters and escaping routines, ensuring they are not inadvertently dropped. Corresponding tests were added to ensure this behavior. [[1]](diffhunk://#diff-9d5feb4307f2574818399596aea67fd5a0a027bf75ad28229dd04bc15d2b8605L45-R62) [[2]](diffhunk://#diff-9d5feb4307f2574818399596aea67fd5a0a027bf75ad28229dd04bc15d2b8605L75-R81) [[3]](diffhunk://#diff-9d5feb4307f2574818399596aea67fd5a0a027bf75ad28229dd04bc15d2b8605L90-R96) [[4]](diffhunk://#diff-465e29fe8f18f9ac8d3e6ef81faa99c065a00f076816d53dec947d858974433dR54-R81) [[5]](diffhunk://#diff-465e29fe8f18f9ac8d3e6ef81faa99c065a00f076816d53dec947d858974433dL74-R110)

**Socket Communication Robustness**
* Improved socket write and read methods in `epp.py` to use `sendall` (ensuring all bytes are sent), handle empty chunks gracefully, and clarify type hints for optional returns. [[1]](diffhunk://#diff-6260ed1fd2a892fcf13b47d28053faafd0a14dd1238b04e5bad240a7c566bb37L189-R173) [[2]](diffhunk://#diff-6260ed1fd2a892fcf13b47d28053faafd0a14dd1238b04e5bad240a7c566bb37L199-R187) [[3]](diffhunk://#diff-6260ed1fd2a892fcf13b47d28053faafd0a14dd1238b04e5bad240a7c566bb37L218-R209)
* Simplified the integer packing logic for message length fields by always using the `">I"` format.

**Documentation and CLI Enhancements**
* Added documentation for the new `poll` CLI command and improved various documentation typos and examples, including correct usage of DNSSEC lists and imports in the usage example. [[1]](diffhunk://#diff-c2a3f968b7ac8d84c3935f76af3a93c094b3c5c068777c4cd2548789b9a8d417R320-R375) [[2]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L7-R7) [[3]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R33) [[4]](diffhunk://#diff-c2a3f968b7ac8d84c3935f76af3a93c094b3c5c068777c4cd2548789b9a8d417L5-R5) [[5]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L139)

**Other Updates**
* Bumped the package version to `0.2.0` and updated development dependencies to their latest versions. [[1]](diffhunk://#diff-dc92b3b0959e219f02b2f23afeab87be3a476f8729f3a85544a5595c1bbe9e74L5-R5) [[2]](diffhunk://#diff-66bb0bc92455abe70f26f42197a234d72e21308eaeb3a5fc17f669dc17707870L1-R4)
* Minor code style and type hint improvements in `base_command.py`. [[1]](diffhunk://#diff-9d5feb4307f2574818399596aea67fd5a0a027bf75ad28229dd04bc15d2b8605R4-R6) [[2]](diffhunk://#diff-9d5feb4307f2574818399596aea67fd5a0a027bf75ad28229dd04bc15d2b8605R27)

These changes collectively enhance PyEPP's reliability, flexibility, and usability for both developers and end users.